### PR TITLE
GossAudit: Linux edition

### DIFF
--- a/Linux/GossAudit.sh
+++ b/Linux/GossAudit.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2020 Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script should be used for Rackspace customers to verify if an operating
+# system is ready to be enrolled in Guest Operating System Services (GOSS)
+
+
+# shellcheck disable=SC2034
+declare -r _VERSION=1.0.0.0
+
+# Exit codes:
+# 1: OS configuration needs correction.
+# 77: Insufficent privileges
+# 131: OS is unsupported.
+
+function check_bash {
+    if [[ $(cut -d . -f 1 <<< "${BASH_VERSION}") -lt "4" ]]; then
+       echo "WARNING: Bash must be at least version 4. OS is unsupported."
+       exit 131
+    fi 
+}
+
+# This function verifies that the version of Enterprise Linux is at a supportable version
+function check_el {
+    # EL 6.8 and 7.5 are the minimum supported versions
+    # EL 4, 5, 8 are unsupported
+    declare -Ar MIN_EL_VERSION=([4]=999 [5]=999 [6]=8 [7]=5 [8]=999)
+
+    el_version=$(grep -oP "\d\.\d\d?" /etc/redhat-release)
+    major_version=$(cut -d . -f 1 <<< "${el_version}")
+    minor_version=$(cut -d . -f 2 <<< "${el_version}")
+
+    if [[ "${minor_version}" -lt "${MIN_EL_VERSION[${major_version}]}" ]]; then
+        echo "WARNING: EL ${el_version} is unsupported."
+        exit 131
+    fi
+}
+
+# This function verifies that the version of Ubuntu is at a supportable version
+function check_debian {
+    # Debian versions are generally a whole number—8, 9, 10,...—and generally not supported
+    # Ubuntu versions look like decimal fractions—14.04,16.04,...
+    declare -ar SUPPORTED_UBUNTU_VERSIONS=( 16.04 18.04 )
+    # shellcheck disable=SC1091
+    source /etc/os-release
+
+    if [[ "${ID}" != "ubuntu" ]]; then
+        echo "WARNING: ${ID} is unsupported."
+        exit 131
+    fi
+
+    if ! grep -q "${VERSION_ID}" <<< "${SUPPORTED_UBUNTU_VERSIONS[*]}"; then
+        echo "WARNING: Ubuntu ${VERSION_ID} is unsupported."
+        exit 131
+    fi
+
+    echo "OS check: OK"
+}
+
+function check_os {
+    # Assume the operating system is some variant of Enterprise Linux if /etc/redhat-release is present
+    if [[ -a /etc/redhat-release ]]; then
+        check_el
+    # Assume the operating system is some variant of Debian if /etc/debian_version is present
+    elif [[ -a /etc/debian_version ]]; then
+        check_debian
+    else
+        echo "WARNING: Unknown OS."
+        exit 131
+    fi
+}
+
+# A server should be able to check for pending updates
+function check_yum {
+    if command -v yum > /dev/null; then
+        # Clear yum/dnf metadata to force yum to check repo data
+        # yum clean metadata can be flakey so we just destroy it all
+        rm -fr /var/cache/{dnf,yum}
+
+        # yum returns with exit code 1 if it fails to pull down any repo metadata
+        yum -q check-update > /dev/null
+        if [[ $? -eq 1 ]]; then
+            echo "WARNING: Yum is unable to check for updates."
+            return 132
+        fi
+        echo "Yum check: OK"
+    fi
+}
+
+function check_dns {
+    declare -ar RACKSPACE_NAMES=(
+        # Rackspace patching internal mirror
+        rax.mirror.rackspace.com
+
+        # generic time server address which points to DFW time server
+        time.rackspace.com
+    )
+
+    for name in "${RACKSPACE_NAMES[@]}"; do
+        if ! getent ahosts "${name}" > /dev/null ; then
+            echo "WARNING: Failed to resolve ${name}"
+            return 130
+        fi
+    done
+
+    echo "DNS check: OK"
+}
+
+function check_users_shell {
+    # The login shell is the last field in the passwd file
+    # Failures can happen if a user does not have a shell set
+    if getent passwd | grep -q ":$"; then
+        echo "WARNING: All users should have a login shell configured"
+        return 133
+    fi
+
+    echo "User shell check: OK"
+}
+
+if [[ $(id -u) -ne 0 ]]; then
+    echo "Script requires superuser privileges"
+    return 77
+fi
+
+# These two functions cause the script to exit if they show issues
+check_bash
+check_os
+
+# All of these functions should run
+# If any of them fail, the script returns with exit code 1.
+
+declare -ar CHECK_FUNCTIONS=(
+    check_users_shell
+    check_dns
+    check_yum
+)
+exit_status=0
+
+for function in "${CHECK_FUNCTIONS[@]}"; do
+    if ! $function ; then
+        exit_status=1
+    fi
+done
+
+exit $exit_status

--- a/Linux/README.md
+++ b/Linux/README.md
@@ -1,0 +1,58 @@
+# GossAudit
+
+A minimal shell script provided by Rackspace to audit Linux Server configuration to ensure they are ready for enrollment automation.
+
+**No changes / installations are performed as part of this script. It is read-only.**
+
+## Prerequisites
+
+- Supported Linux server distribution
+- Bash version 4.0.0+
+
+
+## List of checks performed:
+
+- Operating system is eligible for Rackspace Linux support
+- Operating system can resolve Rackspace service hostnames
+- All users have a login shell configured
+- Verifies Red Hat Enterprise Linux systems can retrieve update packages
+
+## Usage
+Download and execute the shell script GossAudit.sh.
+```bash
+curl -O https://raw.githubusercontent.com/rackerlabs/GossAudit/master/GossAudit.sh
+bash GossAudit.sh
+```
+
+## Recommendations
+
+Output from the script will look like the following:
+
+```bash
+[root@45e11e4385c6 ~]# bash /scripts/GossAudit.sh
+WARNING: All users should have a login shell configured
+DNS check: OK
+Yum check: OK
+[root@45e11e4385c6 ~]# echo $?
+1
+```
+
+In this case the device is not ready for enrollment. The script exited with status code 1 due to a user on the system not having a defined login shell.
+
+When a device is ready for enrollment, the script will return 0:
+
+```bash
+[root@5e8d9e03ec00 ~]# bash /scripts/GossAudit.sh
+User shell check: OK
+DNS check: OK
+Yum check: OK
+[root@5e8d9e03ec00 ~]# echo $?
+0
+```
+
+## Issues
+If you have any technical issues with the module, you can create an issue using the below link:
+
+https://github.com/rackerlabs/GossAudit/issues/new
+
+Any other queries should be directed towards your Rackspace account team.

--- a/Linux/tests/README.md
+++ b/Linux/tests/README.md
@@ -1,0 +1,20 @@
+# Tests
+## Integration
+Integration tests for the bash edition of GossAudit are meant to be run using [Ansible](https://docs.ansible.com/) and [molecule](https://molecule.readthedocs.io/en/latest/).
+
+## Setting up
+Install the latest versions of ansible, molecule, and the Docker driver for molecule.
+```bash
+pipenv install ansible molecule[docker]
+
+python3 -m venv GossAuditIntegration
+source GossAuditIntegration/bin/activate
+pip3 install ansible molecule[docker]
+```
+
+You can then execute different scenarios.
+```bash
+molecule test
+molecule test -s default
+molecule test -s broken_dns
+```

--- a/Linux/tests/integration/README.md
+++ b/Linux/tests/integration/README.md
@@ -1,0 +1,3 @@
+# integration
+This is a small ansible role that executes GossAudit.sh on devices.
+It's mostly meant to integrate with molecule for running integration testing.

--- a/Linux/tests/integration/files/GossAudit.sh
+++ b/Linux/tests/integration/files/GossAudit.sh
@@ -1,0 +1,1 @@
+../../../GossAudit.sh

--- a/Linux/tests/integration/molecule/broken_dns/Dockerfile.j2
+++ b/Linux/tests/integration/molecule/broken_dns/Dockerfile.j2
@@ -1,0 +1,12 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+ RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python3 sudo bash ca-certificates && apt-get clean; \
+     elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python3 sudo python3-dnf bash && dnf clean all; \
+     elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+     elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; fi

--- a/Linux/tests/integration/molecule/broken_dns/converge.yml
+++ b/Linux/tests/integration/molecule/broken_dns/converge.yml
@@ -1,0 +1,13 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Run GossAudit
+      include_role:
+        name: integration
+
+    - name: Verify script execution on supported platforms
+      assert:
+        that: audit_result.rc != 0
+...

--- a/Linux/tests/integration/molecule/broken_dns/molecule.yml
+++ b/Linux/tests/integration/molecule/broken_dns/molecule.yml
@@ -1,0 +1,40 @@
+---
+dependency:
+  enabled: false
+
+driver:
+  name: docker
+
+platforms:
+  - name: goss-audit-dns-c6
+    image: docker.io/library/centos:6
+
+  - name: goss-audit-dns-c7
+    image: docker.io/library/centos:7
+
+  - name: goss-audit-dns-c8
+    image: docker.io/library/centos:8
+
+  - name: goss-audit-dns-u16
+    image: docker.io/library/ubuntu:16.04
+
+  - name: goss-audit-dns-u18
+    image: docker.io/library/ubuntu:18.04
+
+  - name: goss-audit-dns-u20
+    image: docker.io/library/ubuntu:20.04
+
+provisioner:
+  name: ansible
+  options:
+    vv: true
+
+scenario:
+  name: broken_dns
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+    - destroy
+...

--- a/Linux/tests/integration/molecule/broken_dns/prepare.yml
+++ b/Linux/tests/integration/molecule/broken_dns/prepare.yml
@@ -1,0 +1,14 @@
+---
+- name: Break DNS config
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    # copy module does not run well for overwriting /etc/hosts and
+    # /etc/resolv.conf—attempting to do so returns something like:
+    # OSError: [Errno 16] Device or resource busy:
+    # b'/etc/.ansible_tmp54thp4_3resolv.conf' -> b'/etc/resolv.conf'
+    # More research needed.
+    - name: Set instance as its own DNS resolver
+      shell: echo nameserver 127.0.0.1 > /etc/resolv.conf
+...

--- a/Linux/tests/integration/molecule/default/Dockerfile.j2
+++ b/Linux/tests/integration/molecule/default/Dockerfile.j2
@@ -1,0 +1,7 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}

--- a/Linux/tests/integration/molecule/default/converge.yml
+++ b/Linux/tests/integration/molecule/default/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Run GossAudit
+      include_role:
+        name: integration
+
+    - name: Verify script execution on supported platforms
+      assert:
+        that: audit_result.rc == 0
+      when: inventory_hostname in groups["supported"]
+
+    - name: Verify script execution on unsupported platforms
+      assert:
+        that: audit_result.rc != 0
+      when: inventory_hostname in groups["unsupported"]
+...

--- a/Linux/tests/integration/molecule/default/molecule.yml
+++ b/Linux/tests/integration/molecule/default/molecule.yml
@@ -1,0 +1,54 @@
+---
+dependency:
+  enabled: false
+
+driver:
+  name: docker
+
+platforms:
+  - name: goss-audit-c6
+    image: docker.io/library/centos:6
+    groups:
+      - supported
+
+  - name: goss-audit-c7
+    image: docker.io/library/centos:7
+    groups:
+      - supported
+
+  - name: goss-audit-c8
+    image: docker.io/library/centos:8
+
+  - name: goss-audit-u16
+    image: docker.io/library/ubuntu:16.04
+    groups:
+      - supported
+
+  - name: goss-audit-u18
+    image: docker.io/library/ubuntu:18.04
+    groups:
+      - supported
+
+  - name: goss-audit-u20
+    image: docker.io/library/ubuntu:20.04
+    groups:
+      - unsupported
+
+  - name: goss-audit-d9
+    image: docker.io/library/debian:9
+    groups:
+      - unsupported
+
+provisioner:
+  name: ansible
+  options:
+    vv: true
+
+scenario:
+  name: default
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+...

--- a/Linux/tests/integration/molecule/eol_os/Dockerfile.j2
+++ b/Linux/tests/integration/molecule/eol_os/Dockerfile.j2
@@ -1,0 +1,12 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python3 sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python3 sudo python3-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; fi

--- a/Linux/tests/integration/molecule/eol_os/converge.yml
+++ b/Linux/tests/integration/molecule/eol_os/converge.yml
@@ -1,0 +1,13 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Run GossAudit
+      include_role:
+        name: integration
+
+    - name: Verify script execution on supported platforms
+      assert:
+        that: audit_result.rc == 131
+...

--- a/Linux/tests/integration/molecule/eol_os/molecule.yml
+++ b/Linux/tests/integration/molecule/eol_os/molecule.yml
@@ -1,0 +1,27 @@
+---
+driver:
+  name: docker
+
+platforms:
+  - name: goss-audit-eol-c6
+    image: docker.io/library/centos:6.7
+
+  - name: goss-audit-eol-c7
+    image: docker.io/library/centos:7.4.1708
+
+  - name: goss-audit-eol-u14
+    image: docker.io/library/ubuntu:14.04
+
+provisioner:
+  name: ansible
+  options:
+    vv: true
+
+scenario:
+  name: eol_os
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+...

--- a/Linux/tests/integration/molecule/invalid_repo/Dockerfile.j2
+++ b/Linux/tests/integration/molecule/invalid_repo/Dockerfile.j2
@@ -1,0 +1,12 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+ RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python3 sudo bash ca-certificates && apt-get clean; \
+     elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python3 sudo python3-dnf bash && dnf clean all; \
+     elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+     elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; fi

--- a/Linux/tests/integration/molecule/invalid_repo/converge.yml
+++ b/Linux/tests/integration/molecule/invalid_repo/converge.yml
@@ -1,0 +1,13 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Run GossAudit
+      include_role:
+        name: integration
+
+    - name: Verify script execution on supported platforms
+      assert:
+        that: audit_result.rc != 0
+...

--- a/Linux/tests/integration/molecule/invalid_repo/molecule.yml
+++ b/Linux/tests/integration/molecule/invalid_repo/molecule.yml
@@ -1,0 +1,27 @@
+---
+dependency:
+  enabled: false
+
+driver:
+  name: docker
+
+platforms:
+  - name: goss-audit-repo-c6
+    image: docker.io/library/centos:6
+
+  - name: goss-audit-repo-c7
+    image: docker.io/library/centos:7
+
+provisioner:
+  name: ansible
+  options:
+    vv: true
+
+scenario:
+  name: invalid_repo
+  test_sequence:
+    - destroy
+    - create
+    - prepare
+    - converge
+...

--- a/Linux/tests/integration/molecule/invalid_repo/prepare.yml
+++ b/Linux/tests/integration/molecule/invalid_repo/prepare.yml
@@ -1,0 +1,37 @@
+---
+- name: Set up invalid repo
+  hosts: all
+  gather_facts: true
+  gather_subset:
+    - min
+  tasks:
+    - name: Configure invalid yum optical media repo
+      block:
+        - name: Define invalid repo
+          yum_repository:
+            state: present
+            file: installmedia
+            name: installmedia
+            baseurl: file:///mnt/media/
+            description: Invalid media repo
+            enabled: true
+            gpgcheck: false
+
+        - name: Clean metadata
+          command: yum clean metadata
+          args:
+            warn: false
+
+      when: ansible_os_family == "RedHat"
+
+    - name: Configure invalid apt optical media repo
+      block:
+        - name: Define invalid repo
+          apt_repository:
+            state: present
+            update_cache: false
+            filename: installmedia
+            repo: deb file:///mnt/media/repo/ {{ ansible_distribution_release }} main contrib
+
+      when: ansible_os_family == "Debian"
+...

--- a/Linux/tests/integration/tasks/main.yml
+++ b/Linux/tests/integration/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Run precheck script
+  script:
+    cmd: GossAudit.sh
+    executable: bash
+  changed_when: false
+  failed_when: false
+  register: audit_result
+...


### PR DESCRIPTION
The Linux version of GossAudit is written for bash 4.0.0+.

I chose to put it in its own "Linux" subdirectory since it includes some tests written with Ansible and molecule that don't apply to the Windows Powershell code.